### PR TITLE
Remove trailing s

### DIFF
--- a/content/base/src/nsSyncLoadService.cpp
+++ b/content/base/src/nsSyncLoadService.cpp
@@ -45,7 +45,7 @@
 #include "nsIChannel.h"
 #include "nsIDOMLoadListener.h"
 #include "nsIChannelEventSink.h"
-#include "nsIInterfaceRequestor.h"s
+#include "nsIInterfaceRequestor.h"
 #include "nsString.h"
 #include "nsWeakReference.h"
 #include "nsIDocument.h"

--- a/editor/msiediting/src/coalesce/msiBigOpCoalesce.cpp
+++ b/editor/msiediting/src/coalesce/msiBigOpCoalesce.cpp
@@ -7,7 +7,7 @@
 #include "nsCOMPtr.h"
 #include "nsIDOMNode.h"
 #include "nsIEditor.h"
-#include "nsIMutableArray.h"s
+#include "nsIMutableArray.h"
 #include "msiEditingAtoms.h"
 #include "nsIDOMText.h"
 #include "nsIDOMCharacterData.h"


### PR DESCRIPTION
Spurious `s` characters were previously inserted at the end of `#include` statements, apparently for debugging purposes ([1], [2])

These spurious characters break compilation with gcc:
```
...
/<<PKGBUILDDIR>>/level1/level2/mozilla/content/base/src/nsSyncLoadService.cpp:48:10: error: #include expects "FILENAME" or <FILENAME>
   48 | #include "nsIInterfaceRequestor.h"s
...
```
As these characters have presumably served their purpose, please could they be removed?

Thanks.

(Possibly the whole of commit `98d79f5c5fab09e104c32c74e414e58bc8bc8139` could be reverted?)

[1] https://github.com/ScientificWord/mozilla/commit/98d79f5c5fab09e104c32c74e414e58bc8bc8139#diff-90bf432715bbb965f62c79684599d8d166e3004e81a334526a7b4f8f206a512eR48
[2] https://github.com/ScientificWord/mozilla/commit/cc5b30c38d86bb98115e65de47387833600cf9ab#diff-487561abc641237bfada9628aa6fbe72561f113a82f544114377d41fba80451bR10