### PR TITLE
Fix SECMOD_MAKE_NSS_FLAGS macro

### DIFF
--- a/security/nss/lib/pk11wrap/secmodt.h
+++ b/security/nss/lib/pk11wrap/secmodt.h
@@ -337,7 +337,7 @@ typedef PRUint32 PK11AttrFlags;
 #define SECMOD_SLOT_FLAGS "slotFlags=[RSA,DSA,DH,RC2,RC4,DES,RANDOM,SHA1,MD5,MD2,SSL,TLS,AES,Camellia,SHA256,SHA512]"
 
 #define SECMOD_MAKE_NSS_FLAGS(fips,slot) \
-"Flags=internal,critical"fips" slotparams=("#slot"={"SECMOD_SLOT_FLAGS"})"
+"Flags=internal,critical" fips " slotparams=(" #slot "={"SECMOD_SLOT_FLAGS"})"
 
 #define SECMOD_INT_NAME "NSS Internal PKCS #11 Module"
 #define SECMOD_INT_FLAGS SECMOD_MAKE_NSS_FLAGS("",1)


### PR DESCRIPTION
Compilation fails:
```
/<<PKGBUILDDIR>>/level1/level2/mozilla/security/manager/ssl/src/nsPKCS11Slot.cpp: In member function ‘virtual nsresult nsPKCS11ModuleDB::GetInternal(nsIPKCS11Module**)’:
/<<PKGBUILDDIR>>/level1/level2/mozilla/security/manager/ssl/src/nsPKCS11Slot.cpp:425:52: error: unable to find string literal operator ‘operator""fips’ with ‘const char [131]’, ‘long unsigned int’ arguments
  425 |     SECMOD_CreateModule(NULL,SECMOD_INT_NAME, NULL,SECMOD_INT_FLAGS);
      |                                                    ^~~~~~~~~~~~~~~~
/<<PKGBUILDDIR>>/level1/level2/mozilla/security/manager/ssl/src/nsPKCS11Slot.cpp: In member function ‘virtual nsresult nsPKCS11ModuleDB::GetInternalFIPS(nsIPKCS11Module**)’:
/<<PKGBUILDDIR>>/level1/level2/mozilla/security/manager/ssl/src/nsPKCS11Slot.cpp:441:55: error: unable to find string literal operator ‘operator""fips’ with ‘const char [131]’, ‘long unsigned int’ arguments
  441 |     SECMOD_CreateModule(NULL, SECMOD_FIPS_NAME, NULL, SECMOD_FIPS_FLAGS);
      |                                                       ^~~~~~~~~~~~~~~~~
/<<PKGBUILDDIR>>/level1/level2/mozilla/security/manager/ssl/src/nsCrypto.cpp: In function ‘void nsCRMFEncoderItemStore(void*, const char*, long unsigned int)’:
/<<PKGBUILDDIR>>/level1/level2/mozilla/security/manager/ssl/src/nsCrypto.cpp:1702:13: warning: conversion from ‘long unsigned int’ to ‘unsigned int’ may change value [-Wconversion]
 1702 |   dest->len += len;
      |   ~~~~~~~~~~^~~~~~
gmake[9]: *** [/<<PKGBUILDDIR>>/level1/level2/mozilla/config/rules.mk:1292: nsPKCS11Slot.o] Error 1
```
Inserting spaces around `fips` and `#slot` fixes this.