### PR TITLE
 error: template with C linkage

### DIFF
--- a/embedding/browser/gtk/src/gtkmozembed.h
+++ b/embedding/browser/gtk/src/gtkmozembed.h
@@ -40,7 +40,7 @@
 #define gtkmozembed_h
 
 #ifdef __cplusplus
-extern "C" {
+extern "C++" {
 #endif /* __cplusplus */
 
 #include <stddef.h>


### PR DESCRIPTION
`EmbedProgress` fails to build with hunderds of `error: template with C linkage` and ` error: template specialization with C linkage` errors.

```
c++ -o EmbedProgress.o -c -I../../../../dist/include/system_wrappers -include /<<PKGBUILDDIR>>/level1/level2/mozilla/config/gcc_hidden.h -DIMPL_XREAPI -DMOZILLA_INTERNAL_API -D_IMPL_NS_COM -DEXPORT_XPT_API -DEXPORT_XPTC_API -D_IMPL_NS_COM_OBSOLETE -D_IMPL_NS_GFX -D_IMPL_NS_WIDGET -DIMPL_XREAPI -DIMPL_NS_NET -DIMPL_THEBES  -DZLIB_INTERNAL -DOSTYPE=\"Linux5.18\" -DOSARCH=Linux -D_IMPL_GTKMOZEMBED -I.  -I/<<PKGBUILDDIR>>/level1/level2/mozilla/embedding/browser/gtk/src -I. -I../../../../dist/include/xpcom -I../../../../dist/include/content -I../../../../dist/include/string -I../../../../dist/include/docshell -I../../../../dist/include/necko -I../../../../dist/include/widget -I../../../../dist/include/dom -I../../../../dist/include/gfx -I../../../../dist/include/layout -I../../../../dist/include/uriloader -I../../../../dist/include/webbrwsr -I../../../../dist/include/shistory -I../../../../dist/include/embed_base -I../../../../dist/include/windowwatcher -I../../../../dist/include/profdirserviceprovider -I../../../../dist/include/xulapp -I../../../../dist/include   -I../../../../dist/include/gtkembedmoz -I../../../../dist/include/nspr     -I../../../../dist/sdk/include    -fPIC  -Wno-error=narrowing -I/usr/include/freetype2/  -fno-rtti -fno-exceptions -Wall -Wconversion -Wpointer-arith -Woverloaded-virtual -Wsynth -Wno-ctor-dtor-privacy -Wno-non-virtual-dtor -Wcast-align -Wno-long-long -pedantic -fpermissive -fno-strict-aliasing -fshort-wchar -pthread -pipe -DNDEBUG -DTRIMMED -Os -freorder-blocks -fno-reorder-functions  -pthread -I/usr/include/gtk-2.0 -I/usr/include/gtk-unix-print-2.0 -I/usr/include/gtk-2.0 -I/usr/include/atk-1.0 -I/usr/include/gtk-2.0 -I/usr/lib/x86_64-linux-gnu/gtk-2.0/include -I/usr/include/pango-1.0 -I/usr/include/harfbuzz -I/usr/include/pango-1.0 -I/usr/include/fribidi -I/usr/include/harfbuzz -I/usr/include/cairo -I/usr/include/pixman-1 -I/usr/include/uuid -I/usr/include/freetype2 -I/usr/include/gdk-pixbuf-2.0 -I/usr/include/libpng16 -I/usr/include/x86_64-linux-gnu -I/usr/include/libmount -I/usr/include/blkid -I/usr/include/glib-2.0 -I/usr/lib/x86_64-linux-gnu/glib-2.0/include  -Wno-error=narrowing -I/usr/include/freetype2/  -DMOZILLA_CLIENT -include ../../../../mozilla-config.h -Wp,-MD,.deps/EmbedProgress.pp /<<PKGBUILDDIR>>/level1/level2/mozilla/embedding/browser/gtk/src/EmbedProgress.cpp
In file included from /usr/include/glib-2.0/glib/glib-typeof.h:39,
                 from /usr/include/glib-2.0/glib/gatomic.h:28,
                 from /usr/include/glib-2.0/glib/gthread.h:32,
                 from /usr/include/glib-2.0/glib/gasyncqueue.h:32,
                 from /usr/include/glib-2.0/glib.h:32,
                 from ../../../../dist/include/system_wrappers/glib.h:3,
                 from /usr/include/glib-2.0/gobject/gbinding.h:28,
                 from /usr/include/glib-2.0/glib-object.h:22,
                 from ../../../../dist/include/system_wrappers/glib-object.h:3,
                 from /usr/include/glib-2.0/gio/gioenums.h:28,
                 from /usr/include/glib-2.0/gio/giotypes.h:28,
                 from /usr/include/glib-2.0/gio/gio.h:26,
                 from /usr/include/gtk-2.0/gdk/gdkapplaunchcontext.h:30,
                 from /usr/include/gtk-2.0/gdk/gdk.h:32,
                 from ../../../../dist/include/system_wrappers/gdk/gdk.h:3,
                 from /usr/include/gtk-2.0/gtk/gtk.h:32,
                 from ../../../../dist/include/system_wrappers/gtk/gtk.h:3,
                 from /<<PKGBUILDDIR>>/level1/level2/mozilla/embedding/browser/gtk/src/gtkmozembed.h:47,
                 from /<<PKGBUILDDIR>>/level1/level2/mozilla/embedding/browser/gtk/src/gtkmozembed2.cpp:41:
/usr/include/c++/12/type_traits:44:3: error: template with C linkage
   44 |   template<typename _Tp>
      |   ^~~~~~~~
/<<PKGBUILDDIR>>/level1/level2/mozilla/embedding/browser/gtk/src/gtkmozembed.h:43:1: note: ‘extern "C"’ linkage started here
   43 | extern "C" {
      | ^~~~~~~~~~
/usr/include/c++/12/type_traits:61:3: error: template with C linkage
   61 |   template<typename _Tp, _Tp __v>
      |   ^~~~~~~~
/<<PKGBUILDDIR>>/level1/level2/mozilla/embedding/browser/gtk/src/gtkmozembed.h:43:1: note: ‘extern "C"’ linkage started here
   43 | extern "C" {
      | ^~~~~~~~~~
/usr/include/c++/12/type_traits:89:3: error: template with C linkage
   89 |   template<bool __v>
      |   ^~~~~~~~
```

Replacing `extern "C"` with `extern "C++"` allows the build to continue.