### PR TITLE
Build on filesystems with case-sensitive filenames

### DIFF
--- a/prince/base/content/jar.mn
+++ b/prince/base/content/jar.mn
@@ -18,7 +18,7 @@ prince.jar:
 * content/toolbarsOverlay.xul       (toolbarsOverlay.xul)
 * content/toolbarsOverlay.js        (toolbarsOverlay.js)
 * content/mathmlOverlay.js          (mathmlOverlay.js)
-* content/mathmloverlay.xul         (mathmloverlay.xul)
+* content/mathmlOverlay.xul         (mathmlOverlay.xul)
 * content/computeOverlay.js         (computeOverlay.js)
 * content/computeUtils.js           (ComputeUtils.js)
 * content/whitespaceUtils.js        (WhitespaceUtils.js)

--- a/prince/base/content/mathmlOverlay.xul
+++ b/prince/base/content/mathmlOverlay.xul
@@ -917,7 +917,7 @@
 
 <!-- STIX --> 
       <tabpanel id="symbol_stix" align="baseline">
-#include stixButtons.xul
+#include STIXButtons.xul
       </tabpanel>        
       <tabpanel id='cachepanel2' observers="cachepanel"/>
 

--- a/prince/base/content/prince.xul
+++ b/prince/base/content/prince.xul
@@ -55,7 +55,7 @@
 # All sets except for popupsets (commands, keys, stringbundles and broadcasters) *must* go into the
 # prince-sets.inc file for sharing with hiddenWindow.xul.
 #include prince-sets.inc
-#include editorKeys.inc
+#include editorkeys.inc
 
 
 

--- a/prince/sidebar/symbols/content/symbols.xul
+++ b/prince/sidebar/symbols/content/symbols.xul
@@ -773,7 +773,7 @@
               <toolbarbutton id="symbolguilsinglright" />
       </tabpanel> 
       <tabpanel id="symbol_stix" context="symbol-context-menu" mathsym="true" aligh="baseline">
-#include ../../../base/content/stixButtons.xul
+#include ../../../base/content/STIXButtons.xul
       </tabpanel>
       <tabpanel id="cachepanel" context="symbol-context-menu" mathsym="false" align="baseline" ondragdrop = "nsDragAndDrop.drop(event, symObserver);" ondragover="nsDragAndDrop.dragOver(event, symObserver);"
         persist="userlistofsymbols" userlistofsymbols=" symbolpi symboltheta symbolinfty symbolin symbolrightarrow symbolell symbolnabla symbolpartial symbolleq symbolgeq symbolsubset symbolcap symbolcup symboltimes symboldiv symbolpm symbolcirc symbolcdot ">

--- a/xulrunner/app/Makefile.in
+++ b/xulrunner/app/Makefile.in
@@ -286,7 +286,7 @@ clean clobber::
 	rm -rf $(DIST)/$(FRAMEWORK_NAME).framework
 endif
 
-README_FILE = $(topsrcdir)/README.md
+README_FILE = $(topsrcdir)/readme.md
 
 libs::
 	$(SYSINSTALL) $(README_FILE) $(DIST)/bin


### PR DESCRIPTION
Currently Scientific Word fails to build on case-sensitive filesystems due to inconsistencies between how the files are referred to in source files and how they are named in the git repo e.g.
```
/<<PKGBUILDDIR>>/level1/level2/release/xulrunner/config/nsinstall -t /<<PKGBUILDDIR>>/level1/level2/mozilla/README.md ../../dist/bin
/<<PKGBUILDDIR>>/level1/level2/release/xulrunner/config/nsinstall: cannot access /<<PKGBUILDDIR>>/level1/level2/mozilla/README.md: No such file or directory
gmake[8]: *** [Makefile:292: libs] Error 1

```
(The file is in fact called `readme.md`.)

This PR changes the source files to match the case of the filenames. An alternative approach would have been to rename the files to match the source code. 