### PR TITLE
Fix os detection error

### DIFF
--- a/prince/modules/os.jsm
+++ b/prince/modules/os.jsm
@@ -19,7 +19,7 @@ function getOS(window)
    os = 'linux';
    break;
   default:
-   throw('Error: Unknown OS ' + navigator.platform);
+   throw('Error: Unknown OS ' + window.navigator.platform);
    os = "??";
   }
   return os;

--- a/prince/modules/os.jsm
+++ b/prince/modules/os.jsm
@@ -16,6 +16,7 @@ function getOS(window)
    break;
   case 'Linux i686':
   case 'Linux i686 (x86_64)':
+  case 'Linux x86_64':
    os = 'linux';
    break;
   default:


### PR DESCRIPTION
When an unrecognised OS is detected, the following error is logged to the console:
```
[JavaScript Error: "navigator is not defined" {file: "file:///usr/lib/sw/modules/os.jsm" line: 22}]
```
This PR fixes `os.jsm` so that `'Error: Unknown OS '` followed by the string for the OS is logged instead.

In addition, `Linux x86_64` is recognised as `linux`.