### PR TITLE
Update build scripts to Python 3

### DIFF
--- a/config/Expression.py
+++ b/config/Expression.py
@@ -62,7 +62,7 @@ class Expression:
     self.__ignore_whitespace()
     self.e = self.__get_equality()
     if self.content:
-      raise Expression.ParseError, self
+      raise Expression.ParseError(self)
 
   def __get_equality(self):
     """
@@ -115,7 +115,7 @@ class Expression:
       if word_len:
         rv = Expression.__ASTLeaf('string', self.content[:word_len])
       else:
-        raise Expression.ParseError, self
+        raise Expression.ParseError(self)
     self.__strip(word_len)
     self.__ignore_whitespace()
     return rv
@@ -176,7 +176,7 @@ class Expression:
     def __repr__(self):
       return self.value.__repr__()
   
-  class ParseError(StandardError):
+  class ParseError(Exception):
     """
     Error raised when parsing fails.
     It has two members, offset and content, which give the offset of the

--- a/config/Preprocessor.py
+++ b/config/Preprocessor.py
@@ -45,6 +45,7 @@ import os
 import os.path
 import re
 from optparse import OptionParser
+from functools import reduce
 
 # hack around win32 mangling our line endings
 # http://aspn.activestate.com/ASPN/Cookbook/Python/Recipe/65443
@@ -71,7 +72,7 @@ class Preprocessor:
     self.context = Expression.Context()
     for k,v in {'FILE': '',
                 'LINE': 0,
-                'DIRECTORY': os.path.abspath('.')}.iteritems():
+                'DIRECTORY': os.path.abspath('.')}.items():
       self.context[k] = v
     self.disableLevel = 0
     # ifStates can be
@@ -85,21 +86,21 @@ class Preprocessor:
     self.cmds = {}
     for cmd, level in {'define': 0,
                        'undef': 0,
-                       'if': sys.maxint,
-                       'ifdef': sys.maxint,
-                       'ifndef': sys.maxint,
+                       'if': sys.maxsize,
+                       'ifdef': sys.maxsize,
+                       'ifndef': sys.maxsize,
                        'else': 1,
                        'elif': 1,
                        'elifdef': 1,
                        'elifndef': 1,
-                       'endif': sys.maxint,
+                       'endif': sys.maxsize,
                        'expand': 0,
                        'literal': 0,
                        'filter': 0,
                        'unfilter': 0,
                        'include': 0,
                        'includesubst': 0,
-                       'error': 0}.iteritems():
+                       'error': 0}.items():
       self.cmds[cmd] = (level, getattr(self, 'do_' + cmd))
     self.out = sys.stdout
     self.setMarker('#')
@@ -159,7 +160,7 @@ class Preprocessor:
     def handleI(option, opt, value, parser):
       includes.append(value)
     def handleE(option, opt, value, parser):
-      for k,v in os.environ.iteritems():
+      for k,v in os.environ.items():
         self.context[k] = v
     def handleD(option, opt, value, parser):
       vals = value.split('=')
@@ -355,7 +356,7 @@ class Preprocessor:
     current = dict(self.filters)
     for f in filters:
       current[f] = getattr(self, 'filter_' + f)
-    filterNames = current.keys()
+    filterNames = list(current.keys())
     filterNames.sort()
     self.filters = [(fn, current[fn]) for fn in filterNames]
     return
@@ -365,7 +366,7 @@ class Preprocessor:
     for f in filters:
       if f in current:
         del current[f]
-    filterNames = current.keys()
+    filterNames = list(current.keys())
     filterNames.sort()
     self.filters = [(fn, current[fn]) for fn in filterNames]
     return
@@ -408,7 +409,7 @@ class Preprocessor:
     args can either be a file name, or a file-like object.
     Files should be opened, and will be closed after processing.
     """
-    isName = type(args) == str or type(args) == unicode
+    isName = type(args) == str or type(args) == str
     oldWrittenLines = self.writtenLines
     oldCheckLineNumbers = self.checkLineNumbers
     self.checkLineNumbers = False

--- a/config/configobj.py
+++ b/config/configobj.py
@@ -16,7 +16,7 @@
 # http://lists.sourceforge.net/lists/listinfo/configobj-develop
 # Comments, suggestions and bug reports welcome.
 
-from __future__ import generators
+
 
 import sys
 INTP_VER = sys.version_info[:2]
@@ -176,7 +176,7 @@ class Builder:
         return m(o)
     
     def build_List(self, o):
-        return map(self.build, o.getChildren())
+        return list(map(self.build, o.getChildren()))
     
     def build_Const(self, o):
         return o.value
@@ -185,7 +185,7 @@ class Builder:
         d = {}
         i = iter(map(self.build, o.getChildren()))
         for el in i:
-            d[el] = i.next()
+            d[el] = next(i)
         return d
     
     def build_Tuple(self, o):
@@ -203,7 +203,7 @@ class Builder:
         raise UnknownType('Undefined Name')
     
     def build_Add(self, o):
-        real, imag = map(self.build_Const, o.getChildren())
+        real, imag = list(map(self.build_Const, o.getChildren()))
         try:
             real = float(real)
         except TypeError:
@@ -320,7 +320,7 @@ class InterpolationEngine(object):
             This is similar to a depth-first-search algorithm.
             """
             # Have we been here already?
-            if backtrail.has_key((key, section.name)):
+            if (key, section.name) in backtrail:
                 # Yes - infinite loop detected
                 raise InterpolationLoopError(key)
             # Place a marker on our backtrail so we won't come back here again
@@ -549,9 +549,9 @@ class Section(dict):
         creating a new sub-section.
         """
         if not isinstance(key, StringTypes):
-            raise ValueError, 'The key "%s" is not a string.' % key
+            raise ValueError('The key "%s" is not a string.' % key)
         # add the comment
-        if not self.comments.has_key(key):
+        if key not in self.comments:
             self.comments[key] = []
             self.inline_comments[key] = ''
         # remove the entry from defaults
@@ -559,13 +559,13 @@ class Section(dict):
             self.defaults.remove(key)
         #
         if isinstance(value, Section):
-            if not self.has_key(key):
+            if key not in self:
                 self.sections.append(key)
             dict.__setitem__(self, key, value)
         elif isinstance(value, dict) and not unrepr:
             # First create the new depth level,
             # then create the section
-            if not self.has_key(key):
+            if key not in self:
                 self.sections.append(key)
             new_depth = self.depth + 1
             dict.__setitem__(
@@ -578,7 +578,7 @@ class Section(dict):
                     indict=value,
                     name=key))
         else:
-            if not self.has_key(key):
+            if key not in self:
                 self.scalars.append(key)
             if not self.main.stringify:
                 if isinstance(value, StringTypes):
@@ -586,10 +586,10 @@ class Section(dict):
                 elif isinstance(value, (list, tuple)):
                     for entry in value:
                         if not isinstance(entry, StringTypes):
-                            raise TypeError, (
+                            raise TypeError(
                                 'Value is not a string "%s".' % entry)
                 else:
-                    raise TypeError, 'Value is not a string "%s".' % value
+                    raise TypeError('Value is not a string "%s".' % value)
             dict.__setitem__(self, key, value)
 
     def __delitem__(self, key):
@@ -635,7 +635,7 @@ class Section(dict):
         """Pops the first (key,val)"""
         sequence = (self.scalars + self.sections)
         if not sequence:
-            raise KeyError, ": 'popitem(): dictionary is empty'"
+            raise KeyError(": 'popitem(): dictionary is empty'")
         key = sequence[0]
         val =  self[key]
         del self[key]
@@ -666,7 +666,7 @@ class Section(dict):
 
     def items(self):
         """ """
-        return zip((self.scalars + self.sections), self.values())
+        return list(zip((self.scalars + self.sections), list(self.values())))
 
     def keys(self):
         """ """
@@ -678,7 +678,7 @@ class Section(dict):
 
     def iteritems(self):
         """ """
-        return iter(self.items())
+        return iter(list(self.items()))
 
     def iterkeys(self):
         """ """
@@ -688,7 +688,7 @@ class Section(dict):
 
     def itervalues(self):
         """ """
-        return iter(self.values())
+        return iter(list(self.values()))
 
     def __repr__(self):
         return '{%s}' % ', '.join([('%s: %s' % (repr(key), repr(self[key])))
@@ -744,7 +744,7 @@ class Section(dict):
         >>> c2
         {'section1': {'option1': 'False', 'subsection': {'more_options': 'False'}}}
         """
-        for key, val in indict.items():
+        for key, val in list(indict.items()):
             if (key in self and isinstance(self[key], dict) and
                                 isinstance(val, dict)):
                 self[key].merge(val)
@@ -765,7 +765,7 @@ class Section(dict):
         elif oldkey in self.sections:
             the_list = self.sections
         else:
-            raise KeyError, 'Key "%s" not found.' % oldkey
+            raise KeyError('Key "%s" not found.' % oldkey)
         pos = the_list.index(oldkey)
         #
         val = self[oldkey]
@@ -1144,9 +1144,9 @@ class ConfigObj(Section):
         Section.__init__(self, self, 0, self)
         #
         defaults = OPTION_DEFAULTS.copy()
-        for entry in options.keys():
-            if entry not in defaults.keys():
-                raise TypeError, 'Unrecognised option "%s".' % entry
+        for entry in list(options.keys()):
+            if entry not in list(defaults.keys()):
+                raise TypeError('Unrecognised option "%s".' % entry)
         # TODO: check the values too.
         #
         # Add any explicit options to the defaults
@@ -1180,7 +1180,7 @@ class ConfigObj(Section):
                 infile = open(infile).read() or []
             elif self.file_error:
                 # raise an error if the file doesn't exist
-                raise IOError, 'Config file not found: "%s".' % self.filename
+                raise IOError('Config file not found: "%s".' % self.filename)
             else:
                 # file doesn't already exist
                 if self.create_empty:
@@ -1212,7 +1212,7 @@ class ConfigObj(Section):
             # needs splitting into lines - but needs doing *after* decoding
             # in case it's not an 8 bit encoding
         else:
-            raise TypeError, ('infile must be a filename,'
+            raise TypeError('infile must be a filename,'
                 ' file like object, or list of lines.')
         #
         if infile:
@@ -1304,7 +1304,7 @@ class ConfigObj(Section):
             enc = BOM_LIST[self.encoding.lower()]
             if enc == 'utf_16':
                 # For UTF16 we try big endian and little endian
-                for BOM, (encoding, final_encoding) in BOMS.items():
+                for BOM, (encoding, final_encoding) in list(BOMS.items()):
                     if not final_encoding:
                         # skip UTF8
                         continue
@@ -1334,7 +1334,7 @@ class ConfigObj(Section):
             return self._decode(infile, self.encoding)
         #
         # No encoding specified - so we need to check for UTF8/UTF16
-        for BOM, (encoding, final_encoding) in BOMS.items():
+        for BOM, (encoding, final_encoding) in list(BOMS.items()):
             if not line.startswith(BOM):
                 continue
             else:
@@ -1382,7 +1382,7 @@ class ConfigObj(Section):
             # NOTE: Could raise a ``UnicodeDecodeError``
             return infile.decode(encoding).splitlines(True)
         for i, line in enumerate(infile):
-            if not isinstance(line, unicode):
+            if not isinstance(line, str):
                 # NOTE: The isinstance test here handles mixed lists of unicode/string
                 # NOTE: But the decode will break on any non-string values
                 # NOTE: Or could raise a ``UnicodeDecodeError``
@@ -1473,7 +1473,7 @@ class ConfigObj(Section):
                         NestingError, infile, cur_index)
                 #
                 sect_name = self._unquote(sect_name)
-                if parent.has_key(sect_name):
+                if sect_name in parent:
                     self._handle_error(
                         'Duplicate section name at line %s.',
                         DuplicateError, infile, cur_index)
@@ -1519,7 +1519,7 @@ class ConfigObj(Section):
                             comment = ''
                             try:
                                 value = unrepr(value)
-                            except Exception, e:
+                            except Exception as e:
                                 if type(e) == UnknownType:
                                     msg = 'Unknown name or type in value at line %s.'
                                 else:
@@ -1532,7 +1532,7 @@ class ConfigObj(Section):
                         comment = ''
                         try:
                             value = unrepr(value)
-                        except Exception, e:
+                        except Exception as e:
                             if isinstance(e, UnknownType):
                                 msg = 'Unknown name or type in value at line %s.'
                             else:
@@ -1551,7 +1551,7 @@ class ConfigObj(Section):
                             continue
                 #
                 key = self._unquote(key)
-                if this_section.has_key(key):
+                if key in this_section:
                     self._handle_error(
                         'Duplicate keyword name at line %s.',
                         DuplicateError, infile, cur_index)
@@ -1653,7 +1653,7 @@ class ConfigObj(Section):
             if self.stringify:
                 value = str(value)
             else:
-                raise TypeError, 'Value "%s" is not a string.' % value
+                raise TypeError('Value "%s" is not a string.' % value)
         squot = "'%s'"
         dquot = '"%s"'
         noquot = "%s"
@@ -1670,7 +1670,7 @@ class ConfigObj(Section):
             # for normal values either single or double quotes will do
             elif '\n' in value:
                 # will only happen if multiline is off - e.g. '\n' in key
-                raise ConfigObjError, ('Value "%s" cannot be safely quoted.' %
+                raise ConfigObjError('Value "%s" cannot be safely quoted.' %
                     value)
             elif ((value[0] not in wspace_plus) and
                     (value[-1] not in wspace_plus) and
@@ -1678,7 +1678,7 @@ class ConfigObj(Section):
                 quot = noquot
             else:
                 if ("'" in value) and ('"' in value):
-                    raise ConfigObjError, (
+                    raise ConfigObjError(
                         'Value "%s" cannot be safely quoted.' % value)
                 elif '"' in value:
                     quot = squot
@@ -1687,7 +1687,7 @@ class ConfigObj(Section):
         else:
             # if value has '\n' or "'" *and* '"', it will need triple quotes
             if (value.find('"""') != -1) and (value.find("'''") != -1):
-                raise ConfigObjError, (
+                raise ConfigObjError(
                     'Value "%s" cannot be safely quoted.' % value)
             if value.find('"""') == -1:
                 quot = tdquot
@@ -1785,11 +1785,11 @@ class ConfigObj(Section):
                     raise_errors=True,
                     file_error=True,
                     list_values=False)
-            except ConfigObjError, e:
+            except ConfigObjError as e:
                 # FIXME: Should these errors have a reference
                 # to the already parsed ConfigObj ?
                 raise ConfigspecError('Parsing configspec failed: %s' % e)
-            except IOError, e:
+            except IOError as e:
                 raise IOError('Reading configspec failed: %s' % e)
         self._set_configspec_value(configspec, self)
 
@@ -1819,7 +1819,7 @@ class ConfigObj(Section):
             section._cs_section_comments[entry] = configspec.comments[entry]
             section._cs_section_inline_comments[entry] = (
                 configspec.inline_comments[entry])
-            if not section.has_key(entry):
+            if entry not in section:
                 section[entry] = {}
             self._set_configspec_value(configspec[entry], section[entry])
 
@@ -1850,7 +1850,7 @@ class ConfigObj(Section):
         #
         section.configspec = scalars
         for entry in sections:
-            if not section.has_key(entry):
+            if entry not in section:
                 section[entry] = {}
             self._handle_repeat(section[entry], sections[entry])
 
@@ -2027,7 +2027,7 @@ class ConfigObj(Section):
         """
         if section is None:
             if self.configspec is None:
-                raise ValueError, 'No configspec supplied.'
+                raise ValueError('No configspec supplied.')
             if preserve_errors:
                 if VdtMissingValue is None:
                     raise ImportError('Missing validate module.')
@@ -2076,7 +2076,7 @@ class ConfigObj(Section):
                                         val,
                                         missing=missing
                                         )
-            except validator.baseErrorClass, e:
+            except validator.baseErrorClass as e:
                 if not preserve_errors or isinstance(e, VdtMissingValue):
                     out[entry] = False
                 else:
@@ -2260,7 +2260,7 @@ def flatten_errors(cfg, res, levels=None, results=None):
         if levels:
             levels.pop()
         return results
-    for (key, val) in res.items():
+    for (key, val) in list(res.items()):
         if val == True:
             continue
         if isinstance(cfg.get(key), dict):

--- a/config/printconfigsetting.py
+++ b/config/printconfigsetting.py
@@ -3,7 +3,7 @@ import configobj, sys
 try:
     (file, section, key) = sys.argv[1:]
 except ValueError:
-    print "Usage: printconfigsetting.py <file> <section> <setting>"
+    print("Usage: printconfigsetting.py <file> <section> <setting>")
     sys.exit(1)
 
 c = configobj.ConfigObj(file)
@@ -11,11 +11,11 @@ c = configobj.ConfigObj(file)
 try:
     s = c[section]
 except KeyError:
-    print >>sys.stderr, "Section [%s] not found." % section
+    print("Section [%s] not found." % section, file=sys.stderr)
     sys.exit(1)
 
 try:
-    print s[key]
+    print(s[key])
 except KeyError:
-    print >>sys.stderr, "Key %s not found." % key
+    print("Key %s not found." % key, file=sys.stderr)
     sys.exit(1)

--- a/config/tests/unit-Expression.py
+++ b/config/tests/unit-Expression.py
@@ -25,8 +25,8 @@ class TestContext(unittest.TestCase):
 
   def test_in(self):
     """test 'var in context' to not fall for fallback"""
-    self.assert_('FAIL' in self.c)
-    self.assert_('PASS' not in self.c)
+    self.assertTrue('FAIL' in self.c)
+    self.assertTrue('PASS' not in self.c)
 
 class TestExpression(unittest.TestCase):
   """
@@ -48,16 +48,16 @@ class TestExpression(unittest.TestCase):
 
   def test_not(self):
     """Test for the ! operator"""
-    self.assert_(Expression('!0').evaluate(self.c))
-    self.assert_(not Expression('!1').evaluate(self.c))
+    self.assertTrue(Expression('!0').evaluate(self.c))
+    self.assertTrue(not Expression('!1').evaluate(self.c))
 
   def test_equals(self):
     """ Test for the == operator"""
-    self.assert_(Expression('FAIL == PASS').evaluate(self.c))
+    self.assertTrue(Expression('FAIL == PASS').evaluate(self.c))
 
   def test_notequals(self):
     """ Test for the != operator"""
-    self.assert_(Expression('FAIL != 1').evaluate(self.c))
+    self.assertTrue(Expression('FAIL != 1').evaluate(self.c))
 
 if __name__ == '__main__':
   unittest.main()

--- a/config/tests/unit-Preprocessor.py
+++ b/config/tests/unit-Preprocessor.py
@@ -1,6 +1,6 @@
 import unittest
 
-from StringIO import StringIO
+from io import StringIO
 import os
 import sys
 import os.path
@@ -222,7 +222,7 @@ P@VAR@
     caught_msg = None
     try:
       self.pp.do_include(f)
-    except Preprocessor.Error, e:
+    except Preprocessor.Error as e:
       caught_msg = e.args[0][-1]
     self.assertEqual(caught_msg, 'spit this message out')
   

--- a/netwerk/dns/src/prepare_tlds.py
+++ b/netwerk/dns/src/prepare_tlds.py
@@ -37,7 +37,6 @@
 import codecs
 import encodings.idna
 import re
-import sets
 import sys
 
 """
@@ -51,12 +50,12 @@ http://wiki.mozilla.org/Gecko:Effective_TLD_Service
 
 def getEffectiveTLDs(path):
   file = codecs.open(path, "r", "UTF-8")
-  domains = sets.Set()
+  domains = set()
   while True:
     line = file.readline()
     # line always contains a line terminator unless the file is empty
     if len(line) == 0:
-      raise StopIteration
+      return
     line = line.rstrip()
     # comment, empty, or superfluous line for explicitness purposes
     if line.startswith("//") or "." not in line:
@@ -78,7 +77,7 @@ def _normalizeHostname(domain):
   def convertLabel(label):
     if _isASCII(label):
       return label.lower()
-    return encodings.idna.ToASCII(label)
+    return encodings.idna.ToASCII(label).decode("utf-8")
   return ".".join(map(convertLabel, domain.split(".")))
 
 def _isASCII(s):
@@ -140,13 +139,13 @@ def main():
       return "PR_TRUE"
     return "PR_FALSE"
 
-  print "{"
+  print("{")
   for etld in getEffectiveTLDs(sys.argv[1]):
     exception = boolStr(etld.exception())
     wild = boolStr(etld.wild())
-    print '  { "%s", %s, %s },' % (etld.domain(), exception, wild)
-  print "  { nsnull, PR_FALSE, PR_FALSE }"
-  print "}"
+    print(('  { "%s", %s, %s },' % (etld.domain(), exception, wild)))
+  print("  { nsnull, PR_FALSE, PR_FALSE }")
+  print("}")
 
 if __name__ == '__main__':
   main()

--- a/toolkit/xre/make-platformini.py
+++ b/toolkit/xre/make-platformini.py
@@ -12,11 +12,11 @@ o.add_option("--print-buildid", action="store_true", dest="print_buildid")
 (options, args) = o.parse_args()
 
 if options.print_buildid:
-    print datetime.now().strftime('%Y%m%d%H')
+    print(datetime.now().strftime('%Y%m%d%H'))
     sys.exit(0)
 
 if not options.buildid:
-    print >>sys.stderr, "--buildid is required"
+    print("--buildid is required", file=sys.stderr)
     sys.exit(1)
 
 (milestoneFile,) = args
@@ -30,6 +30,6 @@ for line in open(milestoneFile, 'r'):
 
     milestone = line
 
-print """[Build]
+print("""[Build]
 BuildID=%s
-Milestone=%s""" % (options.buildid, milestone)
+Milestone=%s""" % (options.buildid, milestone))


### PR DESCRIPTION
Python 2 has been End of Life since [1st January 2020](https://www.python.org/doc/sunset-python-2/)

This PR updates the Python scripts used during the build process from Python 2 to Python 3. Mostly the updating has been done automatically using the [2to3](https://docs.python.org/3/library/2to3.html) utility. 
```
2to3 -w toolkit/xre/make-platformini.py
2to3 -w config/nsinstall.py 
2to3 -w config/tests/unit-Expression.py
2to3 -w config/tests/unit-Preprocessor.py
2to3 -w config/configobj.py
2to3 -w config/printconfigsetting.py 
2to3 -w config/Preprocessor.py 
2to3 -w config/Expression.py
```

An upstream Mozilla [patch](https://phabricator.services.mozilla.com/rMOZILLACENTRAL25ff3ab8a3415c7ff43b1a05df58b11541561c0e) and some manual tweaks were also required.

Unfortunately some of the changes are not backward compatible with Python 2.

I have not attempted to change the configure files to require Python 3. Instead I have set the `PYTHON` environment variable to instruct them to use Python 3:
```
export PYTHON=python3
make -f mozilla/client.mk build
```